### PR TITLE
fix(brew): replace removed brew bundle --formula switch

### DIFF
--- a/eru.sh
+++ b/eru.sh
@@ -373,13 +373,27 @@ function task_packages() {
   for brewfile in "${brewfiles[@]}"; do
     info "Processing $(basename "$brewfile")..."
     if [[ "$DRY_RUN" != "true" ]]; then
-      local bundle_args=("--file=$brewfile")
+      local effective_brewfile="$brewfile"
+      local tmp_brewfile=""
+
+      # FORMULA_ONLY restricts installation to taps and formulae (skipping
+      # casks, mas, etc). The `--formula` switch was removed from
+      # `brew bundle install`, so filter the Brewfile to formula entries
+      # instead.
+      if [[ "${FORMULA_ONLY:-false}" == "true" ]]; then
+        tmp_brewfile=$(mktemp)
+        grep -E '^[[:space:]]*(tap|brew)[[:space:]]' "$brewfile" > "$tmp_brewfile" || true
+        effective_brewfile="$tmp_brewfile"
+      fi
+
+      local bundle_args=("--file=$effective_brewfile")
       [[ -n "${FORCE:-}" ]] && bundle_args+=("--no-upgrade")
-      [[ "${FORMULA_ONLY:-false}" == "true" ]] && bundle_args+=("--formula")
 
       if ! brew bundle "${bundle_args[@]}"; then
+        [[ -n "$tmp_brewfile" ]] && rm -f "$tmp_brewfile"
         fail "Failed to install packages from $(basename "$brewfile")"
       fi
+      [[ -n "$tmp_brewfile" ]] && rm -f "$tmp_brewfile"
     fi
   done
 


### PR DESCRIPTION
## What

`FORMULA_ONLY` installs in `eru.sh` now filter the Brewfile to `tap`/`brew` entries instead of passing `--formula` to `brew bundle`.

## Why

Homebrew removed the `--formula` switch from the `brew bundle install` subcommand (it now only exists on `add`/`remove`). This broke the `Test Package Installation` CI job with:

```
Invalid usage: The `install` subcommand does not accept the `--formula` switch.
```

The break is environmental, not from a code change, which is why recent pushes to `master` failed in ~15s without touching `eru.sh`. CI last passed on May 6.

## Note

A separate, newer Homebrew 6.0 behavior refuses to load formulae from untrusted custom taps (`d12frosted/emacs-plus`, `tinted-theming/tinted`, etc.) without `brew trust`. If the CI runner has updated to 6.0+, that may surface as a follow-up and need a tap-trust step. Left out of scope here since it's distinct from the logged failure.