### PR TITLE
feat(emacs): add keycast for demo key/command HUD

### DIFF
--- a/emacs/lisp/init-ui.el
+++ b/emacs/lisp/init-ui.el
@@ -313,5 +313,20 @@
 
 
 
+;; show the key + command I just pressed; off by default, toggle on for
+;; demos and screencasts with `keycast-mode-line-mode'.
+;;
+;; pinned to v1.4.7: keycast master (v1.4.8+) requires `cond-let' 1.1,
+;; which is unreleased upstream (cond-let is still at 0.2.0). Drop the
+;; :ref pin once cond-let 1.1 lands.
+(use-package keycast
+  :ensure (keycast :host github :repo "tarsius/keycast" :ref "v1.4.7")
+  :defer t
+  :commands (keycast-mode-line-mode
+             keycast-header-line-mode
+             keycast-log-mode))
+
+
+
 (provide 'init-ui)
 ;;; init-ui.el ends here


### PR DESCRIPTION
Adds `keycast` (deferred, no auto-enable) to show the key + command just pressed — toggle on with `keycast-mode-line-mode` for demos/screencasts.

Pinned to **v1.4.7**: keycast master (v1.4.8+) requires `cond-let` 1.1, which is unreleased upstream (cond-let is still at 0.2.0). The pin can be dropped once cond-let 1.1 lands.