### PR TITLE
fix(emacs): polyfill set-local for Emacs builds without it

### DIFF
--- a/emacs/init.el
+++ b/emacs/init.el
@@ -76,6 +76,16 @@
            "eru install emacs"))
   (load path-autoloads-file nil 'nomessage))
 
+;; Compatibility shim for `set-local'. Emacs 31 introduces it as a
+;; built-in, but this build predates that and `compat' assumes the
+;; native version (so it does not backport it). The upgraded
+;; vertico/consult/marginalia/corfu/cape all call it, so define a
+;; fallback. Remove once the Emacs build provides `set-local' natively.
+(unless (fboundp 'set-local)
+  (defun set-local (variable value)
+    "Set VARIABLE to VALUE buffer-locally."
+    (set (make-local-variable variable) value)))
+
 ;; core
 (require 'init-env)
 (require 'init-kbd)


### PR DESCRIPTION
Emacs 31 introduces `set-local` as a built-in, but builds that predate it crash in the upgraded vertico/consult/marginalia/corfu/cape (which call it), because `compat` assumes the native version and does not backport it. Add a guarded fallback in `init.el` so the whole stack works; the `unless fboundp` guard makes it inert once the Emacs build ships `set-local` natively.