### PR TITLE
feat(emacs): add embark for actions on point and candidates

### DIFF
--- a/emacs/lisp/init-selection.el
+++ b/emacs/lisp/init-selection.el
@@ -155,13 +155,25 @@ _TOTAL arguments."
     "pg" '(consult-grep :which-key "Grep the project")
     "ji" '(consult-imenu :which-key "imenu")))
 
-;; (use-package embark
-;;   :bind
-;;   (("M-." . embark-dwim)
-;;    ("C-." . embark-act)))
+;; act on the thing at point or the current minibuffer candidate; the
+;; "verb layer" on top of vertico/consult/marginalia. `C-;' for dwim
+;; keeps `M-.' free for xref/lsp go-to-definition.
+(use-package embark
+  :ensure t
+  :bind (("C-." . embark-act)
+         ("C-;" . embark-dwim)
+         ("C-h B" . embark-bindings))
+  :config
+  ;; hide the mode line of the Embark live/completions buffers
+  (add-to-list 'display-buffer-alist
+               '("\\`\\*Embark Collect \\(Live\\|Completions\\)\\*"
+                 nil
+                 (window-parameters (mode-line-format . none)))))
 
-;; (use-package embark-conuslt
-;;   :defer t)
+(use-package embark-consult
+  :ensure t
+  :after (embark consult)
+  :hook (embark-collect-mode . consult-preview-at-point-mode))
 
 
 


### PR DESCRIPTION
Adds embark + embark-consult — the "verb layer" on top of vertico/consult/marginalia. `C-.` acts on the thing at point or the current minibuffer candidate, `C-;` runs the default (dwim) action, and `C-h B` lists active bindings. `C-;` is used for dwim so `M-.` stays on xref/lsp go-to-definition.

Installs cleanly at 1.2 now that consult is 3.6 (≥ 3.2) and compat is 31.