### PR TITLE
fix(ssh): drop UseKeychain (unused; breaks Homebrew OpenSSH)

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -11,9 +11,9 @@ Host *
   # Add SSH keys to agent
   AddKeysToAgent yes
 
-  # Use macOS keychain for SSH keys (macOS only)
-  IgnoreUnknown UseKeychain
-  UseKeychain yes
+  # SSH keys are served by gpg-agent (SSH_AUTH_SOCK -> gpg-agent), so macOS
+  # keychain integration (UseKeychain) is not used. It was also an Apple-ssh-only
+  # directive that fatally errors under Homebrew's OpenSSH, so it is omitted.
 
   # Prefer ed25519 keys
   IdentityFile ~/.ssh/id_ed25519


### PR DESCRIPTION
## What

Remove `UseKeychain yes` (and its `IgnoreUnknown UseKeychain` helper) from `ssh/config`.

## Why

SSH authentication is served by gpg-agent (`SSH_AUTH_SOCK` -> gpg-agent, `enable-ssh-support`, `sshcontrol`), so macOS keychain integration was a no-op here. `UseKeychain` is also an Apple-`/usr/bin/ssh`-only directive that fatally errors under Homebrew's OpenSSH (now first in `PATH`).

The config stopped parsing because Conductor injects `Include ~/.ssh/conductor_config` at line 1 of the deployed `~/.ssh/config`, which carries `IgnoreUnknown WarnWeakCrypto`. Since `IgnoreUnknown` is first-value-wins in OpenSSH, it silently overrode the local `IgnoreUnknown UseKeychain` workaround, un-ignoring `UseKeychain` and making Homebrew's ssh reject the config. Removing `UseKeychain` resolves it cleanly under both Apple's and Homebrew's ssh.