### PR TITLE
feat(emacs): add consult-flycheck on M-m je for diagnostics

### DIFF
--- a/emacs/lisp/init-ide.el
+++ b/emacs/lisp/init-ide.el
@@ -86,6 +86,13 @@
   :config
   (global-flycheck-mode +1))
 
+(use-package consult-flycheck
+  :ensure t
+  :defer t
+  :general
+  (leader-def
+    "je" '(consult-flycheck :which-key "diagnostic")))
+
 ;; See lisp/dash-functional.el for more information. Here we simply
 ;; make sure that our mock is loaded instead of upstream.
 (eval-when-compile


### PR DESCRIPTION
Adds `consult-flycheck` — a consult picker over flycheck diagnostics with live preview, bound to `M-m je` (jump-to-error). Sits next to the existing `consult-lsp`.