### PR TITLE
feat(emacs): add difftastic for structural diffs in magit

### DIFF
--- a/brew/Brewfile
+++ b/brew/Brewfile
@@ -77,6 +77,7 @@ cask "gpg-suite"
 #
 
 brew "automake"
+brew "difftastic"
 brew "gh"
 brew "git"
 brew "git-lfs"

--- a/emacs/lisp/init-vcs.el
+++ b/emacs/lisp/init-vcs.el
@@ -113,6 +113,14 @@
   :hook ((prog-mode . turn-on-diff-hl-mode)
          (text-mode . turn-on-diff-hl-mode)))
 
+;; structural (syntax-aware) diffs via the `difft' binary; installs the
+;; bindings into magit (M-d/M-c in the diff transient, M-= in dired)
+;; without eagerly loading magit
+(use-package difftastic-bindings
+  :ensure difftastic
+  :config
+  (difftastic-bindings-mode))
+
 (defun vcs-quit (&optional _kill-buffer)
   "Clean up magit buffers after quitting `magit-status'.
 


### PR DESCRIPTION
Adds `difftastic` — syntax-aware (structural) diffs via the `difft` binary. `difftastic-bindings-mode` wires the commands into magit's diff transient (`M-d` / `M-c`), magit-blame, and dired (`M-=`) without eagerly loading magit. Also adds `brew "difftastic"` to brew/Brewfile so `eru` installs the binary.