### PR TITLE
refactor(emacs): decouple vulpea from the vino/brb wine stack

### DIFF
--- a/emacs/lisp/init-vulpea.el
+++ b/emacs/lisp/init-vulpea.el
@@ -115,8 +115,6 @@
    vulpea-ui-backlinks-preview-lines 2
    vulpea-ui-backlinks-prose-chars-before 30
    vulpea-ui-backlinks-prose-chars-after 50
-   vulpea-ui-backlinks-note-filter (lambda (note)
-                                     (not (vulpea-note-tagged-any-p note "cellar" "rating" "event")))
    vulpea-ui-backlinks-context-types '(meta header list quote code footnote prose)
    vulpea-ui-backlinks-sort 'title-desc
    vulpea-ui-fast-parse t))
@@ -520,13 +518,6 @@
               (list
                url
                package))
-            fancy-yank-format-link))
-    (cons "\\(https://www.vivino.com/.*/?w/\\([[:alnum:]]+.*\\)\\)"
-          '(fancy-yank-extract-regex
-            (lambda (_ query &rest _)
-              (list
-               (concat "https://www.vivino.com/w/" query)
-               "vivino.com"))
             fancy-yank-format-link))
     (cons (concat "^" string-http-url-regexp "$")
           '(fancy-yank-extract-regex

--- a/emacs/lisp/lib-vulpea.el
+++ b/emacs/lisp/lib-vulpea.el
@@ -42,7 +42,6 @@
 (require 'lib-string)
 
 (require 'vulpea)
-(require 'vino)
 (require 'org-attach)
 
 
@@ -69,7 +68,7 @@
   "Return list of candidates for `vulpea-find'.
 
 FILTER is a `vulpea-note' predicate."
-  (let ((notes (vulpea-db-query-by-tags-none '("cellar" "rating" "appellation" "grape" "region" "cemetery"))))
+  (let ((notes (vulpea-db-query-by-tags-none '("cemetery"))))
     (if filter
         (-filter filter notes)
       notes)))
@@ -79,7 +78,7 @@ FILTER is a `vulpea-note' predicate."
   "Return list of candidates for `vulpea-find'.
 
 FILTER is a `vulpea-note' predicate."
-  (let ((notes (vulpea-db-query-by-tags-none '("cellar" "rating" "appellation" "grape" "region"))))
+  (let ((notes (vulpea-db-query-by-tags-none nil)))
     (if filter
         (-filter filter notes)
       notes)))
@@ -327,12 +326,7 @@ useful features and properties:
   "Update notes database."
   (interactive)
   (when (file-directory-p vulpea-directory)
-    (require 'vino)
-    (require 'lib-brb)
-
     (vulpea-db-sync-full-scan)
-    (brb-sync-external-data-with-upstream)
-
     (message " -> done building vulpea db")))
 
 


### PR DESCRIPTION
Prep for removing the unused vino/brb stack: severs vulpea's last ties to it.

- drop the vestigial `(require 'vino)` from lib-vulpea.el (nothing in the file calls a vino function)
- remove the `brb-sync-external-data-with-upstream` step (and its requires) from `vulpea-db-build`, keeping the full-scan
- strip the now-empty wine-tag filters (`cellar`/`rating`/`grape`/`region`/`appellation`) from `vulpea-find-candidates` / `vulpea-insert-candidates` (verified 0 such notes remain in the db) and the `vulpea-ui` backlinks filter (falls back to its `identity` default)
- drop the vivino.com `fancy-yank` rule

No behavior change: the stripped tags match zero notes today.