### PR TITLE
fix(docs): repair CI badge and move it onto the sponsor row

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
   <img width="256px" src="images/d12frosted.png" alt="Banner">
 </p>
 <p align="center">
-  <a href="https://github.com/d12frosted/environment/actions?query=workflow%3ACI">
-    <img src="https://github.com/d12frosted/environment/workflows/ci/badge.svg" alt="CI Status Badge">
+  <a href="https://github.com/d12frosted/environment/actions/workflows/ci.yml">
+    <img src="https://github.com/d12frosted/environment/actions/workflows/ci.yml/badge.svg" alt="CI Status Badge">
   </a>
-
   <a href="https://github.com/sponsors/d12frosted"><img alt="Sponsor" src="https://img.shields.io/badge/Sponsor-d12frosted-pink?logo=githubsponsors&logoColor=white"/></a>
 </p>
 


### PR DESCRIPTION
Follow-up to #69. Two small things in the README header:

- The CI badge was broken. It used the legacy `workflows/ci/badge.svg` URL, which 404s — that format is case-sensitive on the workflow name (`CI`, not `ci`) and is deprecated anyway. Switched to the modern `actions/workflows/ci.yml/badge.svg` form and pointed the link straight at the workflow's runs page. Verified the new URL returns 200 and the old one 404s.
- The CI and Sponsor badges were rendering on separate rows. There was a blank line between the two `<a>` tags inside the centered `<p>`, and GitHub markdown treats a blank line inside an HTML block as a terminator, so the sponsor badge got split onto its own left-aligned row. Dropped the blank line so both badges sit together in one centered row.