### PR TITLE
Make vulpea sync fast and lossless

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ the services via `launchctl`.
 ./eru.sh install services
 ```
 
+The vulpea note sync lives here. `bin/vulpea-sync` mirrors `~/vulpea` to git on
+a 10-minute launchd backstop; `bin/vulpea-watch` (a KeepAlive `fswatch` daemon)
+debounces file changes and kicks off a sync shortly after you stop editing, so a
+burst of edits becomes a single push. Both funnel through `vulpea-sync`, which
+takes a lock so runs never overlap.
+
 ### `emacs`
 Set up Emacs configuration by running `emacs/setup.sh` (bootstraps packages and
 generates autoloads). Supports subtasks via `emacs:<subtask>` syntax, passed
@@ -277,7 +283,7 @@ packages (requires: homebrew)
 wm (requires: packages → yabai, skhd)
 shell (requires: packages → fish)
 devtools (requires: packages → gnupg, ssh)
-services (requires: packages, emacs → vulpea-sync)
+services (requires: packages, emacs → vulpea-sync, vulpea-watch)
 emacs (requires: packages → emacs-plus)
 ```
 

--- a/bin/vulpea-sync
+++ b/bin/vulpea-sync
@@ -3,10 +3,35 @@
 set -e
 
 VULPEA_DIR="${VULPEA_DIR:-$HOME/vulpea}"
+LOCK_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/vulpea-sync/sync.lock"
 
 log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
 }
+
+# Only one sync at a time. The launchd backstop, bin/vulpea-watch and
+# manual runs all funnel through here; macOS has no flock(1), so use an
+# atomic mkdir as the mutex and record the owner pid for staleness checks.
+mkdir -p "$(dirname "$LOCK_DIR")"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  lock_pid="$(cat "$LOCK_DIR/pid" 2>/dev/null || true)"
+  if [ -n "$lock_pid" ]; then
+    if kill -0 "$lock_pid" 2>/dev/null; then
+      log "Another sync is running (pid $lock_pid); skipping"
+      exit 0
+    fi
+    log "Stale lock (dead pid $lock_pid); taking over"
+    rm -rf "$LOCK_DIR"; mkdir "$LOCK_DIR"
+  elif [ -n "$(find "$LOCK_DIR" -maxdepth 0 -mmin +10 2>/dev/null)" ]; then
+    log "Stale lock (no owner, older than 10m); taking over"
+    rm -rf "$LOCK_DIR"; mkdir "$LOCK_DIR"
+  else
+    log "Lock held (acquiring elsewhere); skipping"
+    exit 0
+  fi
+fi
+echo $$ >"$LOCK_DIR/pid"
+trap 'rm -rf "$LOCK_DIR"' EXIT
 
 cd "$VULPEA_DIR"
 

--- a/bin/vulpea-sync
+++ b/bin/vulpea-sync
@@ -9,6 +9,14 @@ log() {
   echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
 }
 
+# Surface actionable failures (e.g. rebase conflicts) so a broken sync
+# does not stay silent. Routine, self-healing hiccups (offline fetch or
+# push) are only logged, to avoid notification spam.
+notify() {
+  command -v terminal-notifier >/dev/null 2>&1 &&
+    terminal-notifier -title "vulpea-sync" -message "$1" >/dev/null 2>&1 || true
+}
+
 # Only one sync at a time. The launchd backstop, bin/vulpea-watch and
 # manual runs all funnel through here; macOS has no flock(1), so use an
 # atomic mkdir as the mutex and record the owner pid for staleness checks.
@@ -64,7 +72,12 @@ log "Fetching from origin..."
 git fetch origin
 
 log "Rebasing on origin/master..."
-git rebase origin/master
+if ! git rebase origin/master; then
+  git rebase --abort || true
+  log "ERROR: rebase conflict; manual resolution required"
+  notify "sync paused: rebase conflict in vulpea notes"
+  exit 1
+fi
 
 log "Pushing to origin..."
 git push origin master

--- a/bin/vulpea-sync
+++ b/bin/vulpea-sync
@@ -40,6 +40,18 @@ log "Syncing vulpea notes in $VULPEA_DIR"
 git config user.name "Golem"
 git config user.email "golem@d12frosted.io"
 
+# Flush unsaved org buffers from the running Emacs so the commit captures
+# the latest edits (agenda todo/refile/schedule changes, etc.) instead of
+# stale on-disk copies. Guard the probe and time-box the eval so a missing
+# server or a stuck minibuffer never wedges the sync.
+if emacsclient --eval t >/dev/null 2>&1; then
+  log "Flushing org buffers via emacsclient..."
+  timeout 30 emacsclient --eval '(ignore-errors (org-save-all-org-buffers))' \
+    >/dev/null 2>&1 || log "WARN: emacsclient flush failed or timed out"
+else
+  log "Emacs server not running; skipping buffer flush"
+fi
+
 git add .
 if git diff-index --quiet --cached HEAD --; then
   log "Nothing to commit"

--- a/bin/vulpea-watch
+++ b/bin/vulpea-watch
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Watch the vulpea notes directory and trigger a debounced sync.
+#
+# fswatch fires on every file change; we wait until things have been
+# quiet for $DEBOUNCE seconds and then run bin/vulpea-sync once. This
+# collapses a burst of edits (or an org-save sweep) into a single push --
+# and therefore a single site rebuild -- while still publishing shortly
+# after you stop editing. bin/vulpea-sync guards against overlapping
+# runs, so this cooperates safely with the launchd backstop.
+#
+# .git and Emacs scratch files (#foo#, .#foo, foo~) are excluded so the
+# sync's own git writes and autosave churn do not feed back into a loop.
+
+set -u
+
+VULPEA_DIR="${VULPEA_DIR:-$HOME/vulpea}"
+SYNC_BIN="${SYNC_BIN:-$HOME/.config/bin/vulpea-sync}"
+DEBOUNCE="${VULPEA_WATCH_DEBOUNCE:-30}"
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log "Watching $VULPEA_DIR (debounce ${DEBOUNCE}s)"
+
+fswatch -o -E \
+  -e '/\.git' \
+  -e '#.*#$' \
+  -e '/\.#' \
+  -e '~$' \
+  "$VULPEA_DIR" |
+while read -r _; do
+  # Coalesce: keep draining events until it has been quiet for $DEBOUNCE
+  # seconds, then sync once.
+  while read -r -t "$DEBOUNCE" _; do :; done
+  log "Changes settled; running sync"
+  "$SYNC_BIN" || log "Sync exited non-zero"
+done

--- a/emacs/lisp/init-vulpea.el
+++ b/emacs/lisp/init-vulpea.el
@@ -37,6 +37,7 @@
 
 (require 'config-path)
 (require 'config-vulpea)
+(require 'lib-buffer)
 
 
 
@@ -570,6 +571,27 @@
   :hook (org-mode . org-emphasis-marker-mode)
   :init
   (setq org-hide-emphasis-markers nil))
+
+
+
+;; Flush notes to disk on idle -----------------------------------------
+;;
+;; Agenda commands (todo state, refile, schedule, ...) and ordinary
+;; edits modify note buffers without writing them, so the files on disk
+;; -- and everything watching them -- fall behind.  In particular the
+;; fswatch-driven vulpea DB and the git mirror (`bin/vulpea-sync', kicked
+;; off by `bin/vulpea-watch') only see saved files.  Save modified org
+;; buffers after a short idle so they stay current without waiting for a
+;; manual save.
+
+(defvar vulpea-idle-save-seconds 30
+  "Idle time in seconds before modified org buffers are saved.")
+
+(defvar vulpea-idle-save-timer
+  (run-with-idle-timer
+   vulpea-idle-save-seconds t
+   (lambda () (buffer-save-modified-in-mode 'org-mode)))
+  "Timer that flushes modified org buffers to disk while idle.")
 
 (provide 'init-vulpea)
 ;;; init-vulpea.el ends here

--- a/emacs/lisp/lib-buffer.el
+++ b/emacs/lisp/lib-buffer.el
@@ -127,6 +127,25 @@ is not present."
         (replace-region-contents l0 l1 (lambda () (funcall fn s)))
         (forward-line)))))
 
+;;;###autoload
+(defun buffer-save-modified-in-mode (mode)
+  "Save modified file-visiting buffers whose major mode derives from MODE.
+
+Saving happens without prompting.  Return the number of buffers
+that were saved.
+
+Handy on an idle timer to flush edits to disk -- for example to
+keep note files current for external tooling that watches the
+file system."
+  (let ((count 0))
+    (save-some-buffers
+     t
+     (lambda ()
+       (and buffer-file-name
+            (derived-mode-p mode)
+            (setq count (1+ count)))))
+    count))
+
 (defun buffer-generate (name &optional unique inhibit-buffer-hooks)
   "Create and return a buffer with a name based on NAME.
 

--- a/emacs/test/lib-buffer-test.el
+++ b/emacs/test/lib-buffer-test.el
@@ -168,5 +168,55 @@
       (expect (buffer-lines buffer) :to-equal expected)
       (expect (current-buffer) :to-equal current-buffer))))
 
+(describe "buffer-save-modified-in-mode"
+  (it "saves modified file buffers whose mode matches"
+    (let ((file (make-temp-file "lib-buffer-test-")))
+      (unwind-protect
+          (let ((buffer (find-file-noselect file)))
+            (unwind-protect
+                (with-current-buffer buffer
+                  (text-mode)
+                  (setq-local require-final-newline nil)
+                  (insert "hello frodo")
+                  (expect (buffer-modified-p) :to-be-truthy)
+                  (expect (buffer-save-modified-in-mode 'text-mode)
+                          :to-equal 1)
+                  (expect (buffer-modified-p) :to-be nil)
+                  (expect (with-temp-buffer
+                            (insert-file-contents file)
+                            (buffer-string))
+                          :to-equal "hello frodo"))
+              (kill-buffer buffer)))
+        (delete-file file))))
+
+  (it "ignores modified buffers of other modes"
+    (let ((file (make-temp-file "lib-buffer-test-")))
+      (unwind-protect
+          (let ((buffer (find-file-noselect file)))
+            (unwind-protect
+                (with-current-buffer buffer
+                  (fundamental-mode)
+                  (insert "hello frodo")
+                  (expect (buffer-save-modified-in-mode 'text-mode)
+                          :to-equal 0)
+                  (expect (buffer-modified-p) :to-be-truthy))
+              (with-current-buffer buffer
+                (set-buffer-modified-p nil))
+              (kill-buffer buffer)))
+        (delete-file file))))
+
+  (it "ignores buffers not visiting a file"
+    (let ((buffer (generate-new-buffer "test-buffer")))
+      (unwind-protect
+          (with-current-buffer buffer
+            (text-mode)
+            (insert "hello frodo")
+            (expect (buffer-save-modified-in-mode 'text-mode)
+                    :to-equal 0)
+            (expect (buffer-modified-p) :to-be-truthy))
+        (with-current-buffer buffer
+          (set-buffer-modified-p nil))
+        (kill-buffer buffer)))))
+
 (provide 'lib-buffer-test)
 ;;; lib-buffer-test.el ends here

--- a/launchd/io.d12frosted.vulpea-watch.plist
+++ b/launchd/io.d12frosted.vulpea-watch.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>io.d12frosted.vulpea-watch</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/d12frosted/.config/bin/vulpea-watch</string>
+    </array>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/bin:/opt/homebrew/bin:/usr/local/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/d12frosted</string>
+        <key>SSH_AUTH_SOCK</key>
+        <string>/Users/d12frosted/.gnupg/S.gpg-agent.ssh</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/d12frosted/.local/share/vulpea-sync/watch-stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/Users/d12frosted/.local/share/vulpea-sync/watch-stderr.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/d12frosted/vulpea</string>
+</dict>
+</plist>


### PR DESCRIPTION
If I make agenda edits (refile, TODO state, schedule) and don't hit save, the org buffers stay modified but unsaved. `vulpea-sync` then commits the stale on-disk copies, so the remote silently lags behind Emacs and I never notice. And syncing only on a 10-minute timer means a note change can take up to 10 min to reach the published site.

This reworks the sync into **debounced event-driven sync + a backstop**:

- **Emacs idle-save** (`buffer-save-modified-in-mode` + a 30s idle timer) writes modified org buffers to disk. This is the bit that makes the file system reflect Emacs — bonus: it keeps the fswatch-driven vulpea DB fresh too.
- **`bin/vulpea-watch`** (new) — a KeepAlive `fswatch` daemon that debounces changes and runs `vulpea-sync` once things settle. A burst of edits collapses to a single push (one site rebuild) shortly after you stop editing, instead of waiting for the timer. `.git` and Emacs scratch files are excluded so the sync's own writes don't loop back.
- **launchd backstop stays at 10 min** — catches non-Emacs changes and the Emacs-was-closed case.
- **`vulpea-sync` hardening**: an atomic `mkdir` lock (no `flock` on macOS) so watcher/backstop/manual runs never overlap; an `emacsclient` flush right before commit (belt-and-suspenders on top of idle-save); and it now aborts + notifies on a rebase conflict instead of silently wedging the repo mid-rebase.

Flow: edit -> (<=30s) idle-save -> fswatch -> (debounce) -> `vulpea-sync` (flush + commit + push). ~1 min latency, one rebuild per burst.

Follow-ups outside this PR:
- The notes repo (`~/vulpea`) has committed Emacs scratch files (`#foo#`, `.#foo`) and no gitignore for them — wants a `.gitignore` + `git rm --cached` over there (separate repo).
- After merge: `./eru.sh install services` to load the watcher, and reload Emacs for the idle-save. I didn't run the live sync end-to-end (it'd push notes / trigger a rebuild); the debounce, exclusions and lock are verified in isolation.