### PR TITLE
feat(emacs): always keep inbox files on the agenda

### DIFF
--- a/emacs/lisp/init-vulpea.el
+++ b/emacs/lisp/init-vulpea.el
@@ -158,6 +158,9 @@
                (not (string-match-p
                      "cemetery"
                      (downcase (or (vulpea-note-path note) "")))))))
+  ;; the inboxes stay on the agenda no matter their content, so an empty
+  ;; inbox is still a reminder to process it
+  (setq vulpea-para-open-work-files '("inbox.org" "inbox-dor.org"))
   :config
   ;; install the opinionated defaults: agenda-mode, the agenda dispatcher
   ;; (with my buffer name and stuck-projects), the prefix-format, and the


### PR DESCRIPTION
`inbox.org` and `inbox-dor.org` should always be on the agenda, even when empty, so an empty inbox still nags me to process it. Right now the `agenda` tag is derived from open work, so an empty inbox quietly falls off.

This sets `vulpea-para-open-work-files` to pin both, so they always count as open work and keep the tag.

Depends on d12frosted/vulpea-para#5, which adds the option. Harmless until that ships and elpaca rebuilds — the current package just ignores the variable.