### PR TITLE
fix(emacs): keep idle org save from mutating buffers

### DIFF
--- a/docs/vulpea-sync.md
+++ b/docs/vulpea-sync.md
@@ -31,7 +31,7 @@ flowchart TD
 
 | Piece | Role |
 |---|---|
-| Emacs idle-save | `buffer-save-modified-in-mode` on a timer (in [`emacs/lisp/init-vulpea.el`](../emacs/lisp/init-vulpea.el), helper in [`emacs/lisp/lib-buffer.el`](../emacs/lisp/lib-buffer.el)) writes modified org buffers to disk after a short idle. |
+| Emacs idle-save | `vulpea-idle-save-flush` on a timer (in [`emacs/lisp/init-vulpea.el`](../emacs/lisp/init-vulpea.el), helper in [`emacs/lisp/lib-buffer.el`](../emacs/lisp/lib-buffer.el)) writes modified org buffers to disk after a short idle. |
 | [`bin/vulpea-watch`](../bin/vulpea-watch) | KeepAlive `fswatch` daemon; debounces file changes and calls `vulpea-sync` once things settle. |
 | [`bin/vulpea-sync`](../bin/vulpea-sync) | Does the actual work: lock, flush unsaved buffers, commit, fetch/rebase, push. |
 | [`launchd/io.d12frosted.vulpea-watch.plist`](../launchd/io.d12frosted.vulpea-watch.plist) | Runs the watcher (KeepAlive). |
@@ -58,6 +58,12 @@ The parts that aren't obvious from reading any single file:
   several writers — mobile captures, the `dor` pipeline, manual commits — so
   pulling is useful work regardless of local changes. Only the final `push` is a
   no-op when idle, and that's a cheap ref check.
+- **Idle-save never edits the buffer.** The flush binds
+  `buffer-save-inhibit-mutations`, which suspends the before-save hooks that
+  mutate content (`vulpea-id-auto-assign` property drawers,
+  `vulpea-ensure-filetag`, ws-butler whitespace trimming). Without this,
+  resuming typing after an idle pause landed in a buffer that had just changed
+  under point. All that maintenance still runs on manual saves.
 - **The emacsclient flush is belt-and-suspenders.** Idle-save usually beats the
   sync, but flushing buffers right before the commit guarantees it captures the
   very latest even if the backstop fires mid-edit.

--- a/emacs/lisp/init-editor.el
+++ b/emacs/lisp/init-editor.el
@@ -97,7 +97,14 @@
   :config
   (setq ws-butler-global-exempt-modes
         (append ws-butler-global-exempt-modes
-                '(special-mode comint-mode term-mode eshell-mode))))
+                '(special-mode comint-mode term-mode eshell-mode)))
+  ;; don't trim whitespace during automatic background saves (e.g. the
+  ;; idle flush of org buffers in init-vulpea), only on manual saves --
+  ;; trimming the trailing space the user just typed mid-sentence is
+  ;; exactly the kind of intrusion background saves must avoid
+  (setq ws-butler-trim-predicate
+        (lambda (_beg _end)
+          (not (bound-and-true-p buffer-save-inhibit-mutations)))))
 
 
 ;; Disable backup files. While I find them useful in general, they

--- a/emacs/lisp/init-vulpea.el
+++ b/emacs/lisp/init-vulpea.el
@@ -588,14 +588,27 @@
 ;; off by `bin/vulpea-watch') only see saved files.  Save modified org
 ;; buffers after a short idle so they stay current without waiting for a
 ;; manual save.
+;;
+;; The flush must be invisible.  Before-save hooks that edit the buffer
+;; (`vulpea-id-auto-assign', `vulpea-pre-save-hook', ws-butler) are
+;; suspended via `buffer-save-inhibit-mutations', otherwise resuming
+;; typing after an idle pause lands in a buffer that just changed under
+;; point (property drawers inserted, whitespace trimmed, undo history
+;; polluted).  All of that maintenance still runs on manual saves.
 
 (defvar vulpea-idle-save-seconds 30
   "Idle time in seconds before modified org buffers are saved.")
 
+(defun vulpea-idle-save-flush ()
+  "Save modified org buffers without mutating their content.
+See `buffer-save-inhibit-mutations'."
+  (let ((buffer-save-inhibit-mutations t)
+        (save-silently t))
+    (buffer-save-modified-in-mode 'org-mode)))
+
 (defvar vulpea-idle-save-timer
   (run-with-idle-timer
-   vulpea-idle-save-seconds t
-   (lambda () (buffer-save-modified-in-mode 'org-mode)))
+   vulpea-idle-save-seconds t #'vulpea-idle-save-flush)
   "Timer that flushes modified org buffers to disk while idle.")
 
 (provide 'init-vulpea)

--- a/emacs/lisp/lib-buffer.el
+++ b/emacs/lisp/lib-buffer.el
@@ -34,6 +34,15 @@
 ;;
 ;;; Code:
 
+(defvar buffer-save-inhibit-mutations nil
+  "Non-nil when buffers are being saved by an automatic background flush.
+
+Save hooks that edit the buffer (id assignment, filetag
+maintenance, whitespace trimming and alike) should check this
+variable and skip their work, so that a background save never
+modifies a buffer under the user.  Manual saves leave it nil, so
+all the maintenance still happens there.")
+
 (defun buffer-content (buffer-or-name)
   "Return content of BUFFER-OR-NAME.
 

--- a/emacs/lisp/lib-vulpea-id.el
+++ b/emacs/lisp/lib-vulpea-id.el
@@ -40,6 +40,7 @@
 ;;; Code:
 
 (require 'org-id)
+(require 'lib-buffer)
 
 (defvar vulpea-id-auto-targets nil
   "Targets for automatic ID assignment.
@@ -55,17 +56,23 @@ Empty list means no id assignment is needed.")
 (defun vulpea-id-auto-assign ()
   "Add ID property to the current file.
 
-Targets are defined by `vulpea-id-auto-targets'."
+Targets are defined by `vulpea-id-auto-targets'.
+
+Does nothing when `buffer-save-inhibit-mutations' is non-nil, so
+that automatic background saves don't edit the buffer under the
+user."
   (when (and vulpea-id-auto-targets
+             (not buffer-save-inhibit-mutations)
              (derived-mode-p 'org-mode)
              (eq buffer-read-only nil))
     (save-excursion
-      (widen)
-      (goto-char (point-min))
-      (when (seq-contains-p vulpea-id-auto-targets 'file)
-        (org-id-get-create))
-      (when (seq-contains-p vulpea-id-auto-targets 'headings)
-        (org-map-entries #'org-id-get-create)))))
+      (save-restriction
+        (widen)
+        (goto-char (point-min))
+        (when (seq-contains-p vulpea-id-auto-targets 'file)
+          (org-id-get-create))
+        (when (seq-contains-p vulpea-id-auto-targets 'headings)
+          (org-map-entries #'org-id-get-create))))))
 
 (provide 'lib-vulpea-id)
 ;;; lib-vulpea-id.el ends here

--- a/emacs/lisp/lib-vulpea.el
+++ b/emacs/lisp/lib-vulpea.el
@@ -38,6 +38,7 @@
 
 (require 'config-vulpea)
 
+(require 'lib-buffer)
 (require 'lib-directory)
 (require 'lib-string)
 
@@ -217,8 +218,13 @@ Uses buffer-local `semantic-nav-prev-fn' if set."
 
 ;;;###autoload
 (defun vulpea-pre-save-hook ()
-  "Do all the dirty stuff when file is being saved."
-  (when (and (not (active-minibuffer-window))
+  "Do all the dirty stuff when file is being saved.
+
+Does nothing when `buffer-save-inhibit-mutations' is non-nil, so
+that automatic background saves don't edit the buffer under the
+user."
+  (when (and (not buffer-save-inhibit-mutations)
+             (not (active-minibuffer-window))
              (vulpea-buffer-p))
     ;; path tags + people; the `agenda' tag is maintained separately by
     ;; `vulpea-para-agenda-mode'

--- a/emacs/test/lib-vulpea-id-test.el
+++ b/emacs/test/lib-vulpea-id-test.el
@@ -1,0 +1,106 @@
+;;; lib-vulpea-id-test.el --- Tests for ID utilities -*- lexical-binding: t; -*-
+;;
+;; Copyright (c) 2015-2026, Boris Buliga <boris@d12frosted.io>
+;;
+;; Author: Boris Buliga <boris@d12frosted.io>
+;; Maintainer: Boris Buliga <boris@d12frosted.io>
+;;
+;; Created: 07 Jul 2026
+;;
+;; URL: https://github.com/d12frosted/environment/tree/master/emacs
+;;
+;; License: GPLv3
+;;
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation, either version 3 of the
+;; License, or (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see
+;; <http://www.gnu.org/licenses/>.
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;; This file contains tests for `lib-vulpea-id' module.
+;;
+;;; Code:
+
+(require 'buttercup)
+(require 'lib-buffer)
+(require 'lib-vulpea-id)
+
+(defun lib-vulpea-id-test--with-org-file (content fn)
+  "Call FN in an `org-mode' buffer visiting a temp file with CONTENT."
+  (let ((file (make-temp-file "lib-vulpea-id-test-" nil ".org")))
+    (unwind-protect
+        (let ((buffer (find-file-noselect file)))
+          (unwind-protect
+              (with-current-buffer buffer
+                (insert content)
+                (org-mode)
+                (funcall fn))
+            (with-current-buffer buffer
+              (set-buffer-modified-p nil))
+            (kill-buffer buffer)))
+      (delete-file file))))
+
+(describe "vulpea-id-auto-assign"
+  (it "does nothing when there are no targets"
+    (lib-vulpea-id-test--with-org-file "* one\n"
+     (lambda ()
+       (let ((vulpea-id-auto-targets nil))
+         (vulpea-id-auto-assign))
+       (expect (buffer-string) :to-equal "* one\n"))))
+
+  (it "assigns file-level ID when file is a target"
+    (lib-vulpea-id-test--with-org-file "* one\n"
+     (lambda ()
+       (let ((vulpea-id-auto-targets '(file)))
+         (vulpea-id-auto-assign))
+       (goto-char (point-min))
+       (expect (org-entry-get nil "ID") :to-be-truthy))))
+
+  (it "assigns ID to every heading when headings is a target"
+    (lib-vulpea-id-test--with-org-file "* one\n* two\n"
+     (lambda ()
+       (let ((vulpea-id-auto-targets '(headings)))
+         (vulpea-id-auto-assign))
+       (goto-char (point-min))
+       (search-forward "* one")
+       (expect (org-entry-get nil "ID") :to-be-truthy)
+       (search-forward "* two")
+       (expect (org-entry-get nil "ID") :to-be-truthy))))
+
+  (it "preserves narrowing"
+    (lib-vulpea-id-test--with-org-file "* one\n* two\n"
+     (lambda ()
+       (goto-char (point-min))
+       (search-forward "* two")
+       (org-narrow-to-subtree)
+       (let ((vulpea-id-auto-targets '(file headings)))
+         (vulpea-id-auto-assign))
+       (expect (buffer-narrowed-p) :to-be-truthy)
+       ;; ids are still assigned outside of the narrowed region
+       (save-restriction
+         (widen)
+         (goto-char (point-min))
+         (expect (org-entry-get nil "ID") :to-be-truthy)))))
+
+  (it "does nothing when buffer-save-inhibit-mutations is non-nil"
+    (lib-vulpea-id-test--with-org-file "* one\n"
+     (lambda ()
+       (let ((vulpea-id-auto-targets '(file headings))
+             (buffer-save-inhibit-mutations t))
+         (vulpea-id-auto-assign))
+       (expect (buffer-string) :to-equal "* one\n")))))
+
+(provide 'lib-vulpea-id-test)
+;;; lib-vulpea-id-test.el ends here


### PR DESCRIPTION
The idle save for org files (the one feeding vulpea-watch and the DB) was pretty intrusive while typing: pause for 30s and the buffer changes under you. Property drawers pop in from `vulpea-id-auto-assign`, `vulpea-ensure-filetag` rewrites the header, ws-butler eats the trailing space you just typed, and undo gets polluted with all of it. Bonus bug: `vulpea-id-auto-assign` called `(widen)` inside `save-excursion` only, which doesn't restore narrowing — so an idle save would silently widen a narrowed buffer.

The fix: a new `buffer-save-inhibit-mutations` flag in lib-buffer. The idle flush binds it (together with `save-silently`, so no more echo area spam) and the mutating save hooks — `vulpea-id-auto-assign`, `vulpea-pre-save-hook`, ws-butler via `ws-butler-trim-predicate` — skip their work when it's set. Manual saves behave exactly as before, so files on disk still get their ids, filetags and whitespace cleanup, and the sync pipeline is unaffected. The narrowing bug is fixed with `save-restriction`.

Also updated docs/vulpea-sync.md to document the non-mutating flush, and added buttercup tests for `vulpea-id-auto-assign` (including narrowing preservation and the inhibit flag).

Already live-verified: hot-loaded into my running Emacs and the flush runs clean.